### PR TITLE
Make tst file independent of SizeScreen output

### DIFF
--- a/tst/introduction.tst
+++ b/tst/introduction.tst
@@ -1,7 +1,6 @@
 gap> START_TEST("Predicata package: introduction.tst");
 
-gap> SizeScreen([100]);
-[ 100, 40 ]
+gap> SizeScreen([100]);;
 gap> A:=Predicaton("(E x:(E y:(E z:6*x+9*y+20*z=n)))");
 Predicaton: deterministic finite automaton on 2 letters with 17 states, the variable position list\
  [ 1 ] and the following transitions:


### PR DESCRIPTION
Since the SizeScreen call in the .tst file only requested a certain number
of columns, the number of rows is variable, and should not be tested.